### PR TITLE
FileInvite: Number of major Issues with Form viewer

### DIFF
--- a/app/components/PDFViewer/signingDemo.tsx
+++ b/app/components/PDFViewer/signingDemo.tsx
@@ -174,7 +174,7 @@ const SignDemo: React.FC<{ allUsers: User[]; user: User }> = ({ allUsers, user }
         }).then(async function (inst: any) {
           trackInst = inst;
           setInstance(inst);
-        
+
           // **** Getting Digital Signature Info ****
           const info = await inst.getSignaturesInfo();
           if(info.status === "valid" || info.status === "warning") digitallySigned = info;
@@ -196,10 +196,42 @@ const SignDemo: React.FC<{ allUsers: User[]; user: User }> = ({ allUsers, user }
           };
 
           // **** Handling Add Signature / Initial UI ****
+          // START - FILEINVITE CONSOLE LOGS
+          inst.addEventListener('document.saveStateChange', async (event: any) => {
+            if (event.hasUnsavedChanges && inst) {
+              console.log({
+                test: 'document.saveStateChange',
+                changes: event.hasUnsavedChanges,
+              });
+            }
+          });
+
+          inst.addEventListener("formFieldValues.update", (formFields: any) => {
+            if (formFields) {
+              const fields = formFields
+                  .map((formField: any) => {
+                    if (formField) {
+                      return {
+                        name: formField.name,
+                        value: formField['value']
+                      };
+                    }
+
+                    return formField;
+                  })
+                  .toArray();
+
+              console.log({
+                test: 'formFieldValues.update',
+                updatedFormFields: fields
+              });
+            }
+          });
+          // END - FILEINVITE CONSOLE LOGS
 
           // Track which signature form field was clicked on
           // and wether it was an initial field or not.
-          inst.addEventListener("annotations.press", 
+          inst.addEventListener("annotations.press",
             (event: any) => {
             let lastFormFieldClicked = event.annotation;
 


### PR DESCRIPTION
We have number of issues when integrating the demo in our project. We have raised a support ticket as well 
https://support.nutrient.io/hc/requests/122369 

1.  While filling form fields like Text box and check box upon typing text field on out of focus the text field reverts to the old value but we can see the form fields values updated on the instance but not appearing in the UI, here's a loom video explaining this problem [https://www.loom.com/share/7b00e71c77fc43578ec42fec4d9bf82c](https://www.loom.com/share/7b00e71c77fc43578ec42fec4d9bf82c) 

2. Radio buttons are not working as per expectation, most of the time all the options are being shown as selected.

3. Files containing # characters breaks the form filling [https://www.loom.com/share/e3ef4931879a496597e663f506671088?sid=6be8a076-7654-4f87-9697-f0f99e371017](https://www.loom.com/share/e3ef4931879a496597e663f506671088?sid=6be8a076-7654-4f87-9697-f0f99e371017)

**FileInvite portal with Nutrient viewer**
You can see the nutrient form viewer experience on this portal here, you can also signup with us to view the Nutrient form creator and viewer here to replicate the issue.

[https://secure.preprod.fileinvite.info/xaBGxVW976/SZEnL2FYkl/portal/88a8e0cf-2250-4a6e-9d14-7e3ed156d716?signature=332054b283263772dddd5a50e6be9f5534feda52407bdf6c0308b1fedca87199471fdcdcccb86353755e169165ad328765ea5a05ec3f62def41e09714c397493&region=au&src=email](https://secure.preprod.fileinvite.info/xaBGxVW976/SZEnL2FYkl/portal/88a8e0cf-2250-4a6e-9d14-7e3ed156d716?signature=332054b283263772dddd5a50e6be9f5534feda52407bdf6c0308b1fedca87199471fdcdcccb86353755e169165ad328765ea5a05ec3f62def41e09714c397493&region=au&src=email)